### PR TITLE
Fix for compatibility with Pyro4 version 4.55

### DIFF
--- a/MaxiNet/FrontendServer/server.py
+++ b/MaxiNet/FrontendServer/server.py
@@ -6,6 +6,7 @@ import threading
 import time
 
 import Pyro4
+import Pyro4.naming
 
 from MaxiNet.tools import MaxiNetConfig
 


### PR DESCRIPTION
Problem when used with Pyro4 >= 4.55. This fix is also available from kilda's upstream repo so you might want to merge it from there as part of a larger merge.